### PR TITLE
Bugfix: `estimate_requests` wasn't returning a value for 1-query requests

### DIFF
--- a/R/freeform_report.R
+++ b/R/freeform_report.R
@@ -262,9 +262,9 @@ n_queries <- function(top) {
 #' @return Number of requests necessary to complete query
 #' @noRd
 estimate_requests <- function(top) {
-  if (length(top) > 1) {
-    queries <- n_queries(top)
+  queries <- n_queries(top)
 
+  if (length(top) > 1) {
     # I reckon about 1 second per query
     # sec
     est_secs <- round(queries * 1.1, digits = 0)
@@ -282,9 +282,9 @@ estimate_requests <- function(top) {
     }
 
     message('Estimated runtime: ', message_text)
-
-    queries
   }
+
+  queries
 }
 
 


### PR DESCRIPTION
Old behavior: For requests with 1 query, `estimate_requests` returned `NULL`, which threw an error later in the `aw_freeform_table` function

New behavior: Now it returns the right number of requests (one) but still doesn't produce error messages

- [x] R CMD check ran with 0 errors, 0 warnings, and 0 notes
- [x] I ran a battery of queries, none threw errors
