### PR TITLE
Hotfix/segment rsids

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,28 +1,4 @@
-feature/unittests:
-  - `metric_container` no longer requires you supply a vector of metric IDs.
-  You can generate a unique list of vector IDs with the utility function
-  `create_metric_column_id`. 
-  - I extracted the formatting of the `top` argument into a utility function
-  called `make_explicit_top`. It doesn't replace zeros, but it obeys the rules
-  for making implicit 'top' arguments into explicit values, and recycles 'top'
-  while following the rules. I renamed `top_daterange_number` to
-  `recalculate_top_arg` to better describe what it does. It also now returns a
-  named character vector (pairing dimensions and their respective 'top'
-  values), which is good for debugging but otherwise has no effect on the
-  results.  
-  - I cleaned up the functionality of `global_filter` so that you can pass it
-  arguments more intuitively. Only `segmentId` and `dateRange` are required,
-  so you can focus on which values you want rather than where to put NAs like
-  before. The `type` argument is handled automatically as well, to reduce
-  errors.
-  - I wrote many unit tests for functions mentioned above, and others. In
-  addition to unit tests for functions that don't require an internet
-  connection, I'm planning "acceptance tests" that run a gamut of queries
-  trying to trip up the package.
-    - In particular, unit tests exist to differing extents for: all functions
-    in `request_format.R`, `make_timeframe`, `recalculate_top_arg`, and
-    `make_expicit_top`. 
-  - I refactored all of the `get_*` functions, outsourcing the formatting of
-  the parameter lists to the function `format_URL_parameters` (which I took
-  the basic components of from the `httr` R package). 
-
+hotfix/segment-rsids
+  - There is now a second argument for Report Suite ID for `aw_segment_table`,
+  which allows the user to specify a vector of RSIDs for which to search for
+  the segment IDs when making pretty names. 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,28 @@
+feature/unittests:
+  - `metric_container` no longer requires you supply a vector of metric IDs.
+  You can generate a unique list of vector IDs with the utility function
+  `create_metric_column_id`. 
+  - I extracted the formatting of the `top` argument into a utility function
+  called `make_explicit_top`. It doesn't replace zeros, but it obeys the rules
+  for making implicit 'top' arguments into explicit values, and recycles 'top'
+  while following the rules. I renamed `top_daterange_number` to
+  `recalculate_top_arg` to better describe what it does. It also now returns a
+  named character vector (pairing dimensions and their respective 'top'
+  values), which is good for debugging but otherwise has no effect on the
+  results.  
+  - I cleaned up the functionality of `global_filter` so that you can pass it
+  arguments more intuitively. Only `segmentId` and `dateRange` are required,
+  so you can focus on which values you want rather than where to put NAs like
+  before. The `type` argument is handled automatically as well, to reduce
+  errors.
+  - I wrote many unit tests for functions mentioned above, and others. In
+  addition to unit tests for functions that don't require an internet
+  connection, I'm planning "acceptance tests" that run a gamut of queries
+  trying to trip up the package.
+    - In particular, unit tests exist to differing extents for: all functions
+    in `request_format.R`, `make_timeframe`, `recalculate_top_arg`, and
+    `make_expicit_top`. 
+  - I refactored all of the `get_*` functions, outsourcing the formatting of
+  the parameter lists to the function `format_URL_parameters` (which I took
+  the basic components of from the `httr` R package). 
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: adobeanalyticsr
 Type: Package
-Version: 0.2.1
+Version: 0.2.1.001
 Title: R Client for 'Adobe Analytics' API 2.0
 Description: Connect to the 'Adobe Analytics' API v2.0 <https://github.com/AdobeDocs/analytics-2.0-apis>
              which powers 'Analysis Workspace'. The package was developed

--- a/R/freeform_segments.R
+++ b/R/freeform_segments.R
@@ -27,7 +27,10 @@
 #'
 #'
 #' @param company_id Company ID
-#' @param rsid Reportsuite ID
+#' @param rsid Report suite ID for the data pull
+#' @param segmentRsids Vector of report suite IDs used to discover the
+#'   human-readable segment names. Passed to `aw_get_segments`. If `NULL`, then
+#'   takes the same value as `rsid`.
 #' @param date_range Date range
 #' @param metrics Metrics to request for each segment
 #' @param globalSegment One or more segments to apply globally over all other
@@ -43,6 +46,7 @@
 #' @export
 aw_segment_table <- function(company_id = Sys.getenv("AW_COMPANY_ID"),
                              rsid = Sys.getenv("AW_REPORTSUITE_ID"),
+                             segmentRsids = NULL,
                              date_range = c(Sys.Date()-30, Sys.Date()-1),
                              metrics = c("visits", "visitors"),
                              globalSegment = NULL,
@@ -51,6 +55,8 @@ aw_segment_table <- function(company_id = Sys.getenv("AW_COMPANY_ID"),
   if (length(segmentIds) == 0) {
     stop("At least one segment ID must be given", call. = FALSE)
   }
+
+  segmentRsids <- segmentRsids %||% rsid
   # Generate requests
   # 1 request group for each unique metric
   # Page the segments into groups of 9 or 10
@@ -74,6 +80,7 @@ aw_segment_table <- function(company_id = Sys.getenv("AW_COMPANY_ID"),
                             metrics = met,
                             globalSegment = globalSegment,
                             segmentIds = seg_group,
+                            segmentRsids = segmentRsids,
                             debug = debug)
 
       increment_global_counter()
@@ -162,6 +169,7 @@ aw_segment_table_page <- function(company_id = Sys.getenv("AW_COMPANY_ID"),
                              metrics = c("visits", "visitors"),
                              globalSegment = NULL,
                              segmentIds = NULL,
+                             segmentRsids = NULL,
                              debug = FALSE) {
   metrics <- unique(metrics)
 
@@ -204,8 +212,6 @@ aw_segment_table_page <- function(company_id = Sys.getenv("AW_COMPANY_ID"),
     settings = settings
   )
 
-  # jsonlite::toJSON(req, pretty = TRUE, auto_unbox = TRUE)
-
   output_data <- jsonlite::fromJSON(aw_call_data(
     req_path = "reports/ranked",
     body = req,
@@ -219,7 +225,7 @@ aw_segment_table_page <- function(company_id = Sys.getenv("AW_COMPANY_ID"),
   )
 
   output_data <- left_join(seg_ctrl, long_metrics, by = c("metric_id" = "name"))
-  output_data <- make_pretty_segments(rsid = rsid,
+  output_data <- make_pretty_segments(rsid = segmentRsids,
                        company_id = company_id,
                        df = output_data)
 

--- a/man/aw_segment_table.Rd
+++ b/man/aw_segment_table.Rd
@@ -7,6 +7,7 @@
 aw_segment_table(
   company_id = Sys.getenv("AW_COMPANY_ID"),
   rsid = Sys.getenv("AW_REPORTSUITE_ID"),
+  segmentRsids = NULL,
   date_range = c(Sys.Date() - 30, Sys.Date() - 1),
   metrics = c("visits", "visitors"),
   globalSegment = NULL,
@@ -17,7 +18,11 @@ aw_segment_table(
 \arguments{
 \item{company_id}{Company ID}
 
-\item{rsid}{Reportsuite ID}
+\item{rsid}{Report suite ID for the data pull}
+
+\item{segmentRsids}{Vector of report suite IDs used to discover the
+human-readable segment names. Passed to \code{aw_get_segments}. If \code{NULL}, then
+takes the same value as \code{rsid}.}
 
 \item{date_range}{Date range}
 


### PR DESCRIPTION
This is a quick one. A segment may be associated with some report suite, but this does not mean it only works with that report suite. It may be a valid segment definition for other report suites. 

Currently `aw_segment_table` looks up segment _names_ (using their segment IDs) using the same report suite that it's searching for data in. However, sometimes you want to use segments associated with a few different report suites while querying data from a single report suite. 

That's why I wanted to add this parameter, `segmentRsids`. It's used to look up the segment names. 

For backwards compatibility, `segmentRsids` defaults to the `rsid` argument, making the exact same behavior as before. 