### PR TITLE
Unname elements of global_filter

### DIFF
--- a/R/request_format.R
+++ b/R/request_format.R
@@ -57,6 +57,8 @@ global_filter <- function(segmentId = NULL,
   if (is.null(dateRange)) {
     dates <- NULL
   } else {
+    # unname() is necessary because lapply picks up names
+    dateRange <- unname(dateRange)
     dates <- lapply(dateRange, function(date) {
       global_filter_elem("dateRange", dateRange = dateRange)
     })
@@ -65,6 +67,8 @@ global_filter <- function(segmentId = NULL,
   if (is.null(segmentId)) {
     segments <- NULL
   } else {
+    # unname() is necessary because lapply picks up names
+    segmentId <- unname(segmentId)
     segments <- lapply(segmentId, function(seg) {
       global_filter_elem("segment", segmentId = seg)
     })

--- a/tests/testthat/test-request_format.R
+++ b/tests/testthat/test-request_format.R
@@ -56,6 +56,17 @@ test_that("global_filter throws an error with more than one daterange filter", {
 })
 
 
+test_that("global_filter throws out names of either the dates or segmentIds", {
+  filt <- global_filter(segmentId = c("My Segment" = "segid"),
+                        dateRange = c("My Date" = "really-long-daterange-string"))
+
+  filt_exp_a <- list(type = "dateRange", dateRange = "really-long-daterange-string")
+  filt_exp_b <- list(type = "segment", segmentId = "segid")
+
+  expect_identical(filt, list(filt_exp_a, filt_exp_b))
+})
+
+
 # Metric elements ----
 test_that("metric_elem works as expected", {
   elem1 <- metric_elem(id = 'theID', columnId = "colID", filters = "filt1", sort = "asc")


### PR DESCRIPTION
Unnaming vectors at the filter construction stage, because a valid
global filter construct has no named elements except for proper ones. We
could strip all names in aw_freeform table, too, but this is less
invasive.

Resolves #131.