### PR TITLE
Remove use_oob deprecation warning and argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: adobeanalyticsr
 Type: Package
-Version: 0.3.2
+Version: 0.3.3
 Title: R Client for 'Adobe Analytics' API 2.0
 Description: Connect to the 'Adobe Analytics' API v2.0 <https://github.com/AdobeDocs/analytics-2.0-apis>
              which powers 'Analysis Workspace'. The package was developed

--- a/R/get_metrics.R
+++ b/R/get_metrics.R
@@ -47,10 +47,8 @@ aw_get_metrics <- function(rsid = Sys.getenv("AW_REPORTSUITE_ID"),
                            segmentable = 'NULL',
                            expansion = NULL,
                            company_id = Sys.getenv("AW_COMPANY_ID"),
-                           debug = FALSE,
-                           use_oob){
+                           debug = FALSE){
   # Reference: https://adobedocs.github.io/analytics-2.0-apis/#/metrics/getMetrics
-  lifecycle::deprecate_warn("0.2.2", what = "aw_get_metrics(use_oob)")
 
   assertthat::assert_that(
     assertthat::is.string(rsid)

--- a/man/aw_get_metrics.Rd
+++ b/man/aw_get_metrics.Rd
@@ -10,8 +10,7 @@ aw_get_metrics(
   segmentable = "NULL",
   expansion = NULL,
   company_id = Sys.getenv("AW_COMPANY_ID"),
-  debug = FALSE,
-  use_oob
+  debug = FALSE
 )
 }
 \arguments{


### PR DESCRIPTION
I haven't heard any complaints about this argument being removed, and
the warning is pretty annoying. I think it's time to seal this up.