### PR TITLE
Deprecate `segmentRsids` argument to `aw_segment_table`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,6 @@ Imports:
     openssl,
     lifecycle,
     glue,
-    tibble,
     vctrs,
     progress,
     memoise,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: adobeanalyticsr
 Type: Package
-Version: 0.3.3
+Version: 0.3.4
 Title: R Client for 'Adobe Analytics' API 2.0
 Description: Connect to the 'Adobe Analytics' API v2.0 <https://github.com/AdobeDocs/analytics-2.0-apis>
              which powers 'Analysis Workspace'. The package was developed
@@ -44,7 +44,7 @@ Suggests:
     knitr,
     testthat (>= 3.0.0),
     rmarkdown
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 Roxygen: list(markdown = TRUE)
 RdMacros: lifecycle
 VignetteBuilder: knitr

--- a/R/freeform_segments.R
+++ b/R/freeform_segments.R
@@ -28,9 +28,6 @@
 #'
 #' @param company_id Company ID
 #' @param rsid Report suite ID for the data pull
-#' @param segmentRsids Vector of report suite IDs used to discover the
-#'   human-readable segment names. Passed to `aw_get_segments`. If `NULL`, then
-#'   takes the same value as `rsid`.
 #' @param date_range Date range
 #' @param metrics Metrics to request for each segment
 #' @param globalSegment One or more segments to apply globally over all other
@@ -39,6 +36,7 @@
 #'   table
 #' @param debug Logical, whether to make verbose requests to the API and view
 #' the whole exchange
+#' @param segmentRsids Deprecated.
 #'
 #' @return [tibble::tibble()] of segments and metrics. Rows are returned with
 #' segments in the order they were requested, not by metric sorting.
@@ -46,7 +44,7 @@
 #' @export
 aw_segment_table <- function(company_id = Sys.getenv("AW_COMPANY_ID"),
                              rsid = Sys.getenv("AW_REPORTSUITE_ID"),
-                             segmentRsids = NULL,
+                             segmentRsids,
                              date_range = c(Sys.Date()-30, Sys.Date()-1),
                              metrics = c("visits", "visitors"),
                              globalSegment = NULL,
@@ -56,7 +54,10 @@ aw_segment_table <- function(company_id = Sys.getenv("AW_COMPANY_ID"),
     stop("At least one segment ID must be given", call. = FALSE)
   }
 
-  segmentRsids <- segmentRsids %||% rsid
+  if (!missing(segmentRsids)) {
+    lifecycle::deprecate_warn(when = "0.3.4", what = "aw_segment_table(segmentRsids)")
+  }
+
   # Generate requests
   # 1 request group for each unique metric
   # Page the segments into groups of 9 or 10
@@ -80,7 +81,7 @@ aw_segment_table <- function(company_id = Sys.getenv("AW_COMPANY_ID"),
                             metrics = met,
                             globalSegment = globalSegment,
                             segmentIds = seg_group,
-                            segmentRsids = segmentRsids,
+                            segmentRsids = NULL,
                             debug = debug)
 
       increment_global_counter()

--- a/man/aw_auth.Rd
+++ b/man/aw_auth.Rd
@@ -56,11 +56,11 @@ and \code{auth_jwt()} should typically not be called directly.
 }
 \section{Functions}{
 \itemize{
-\item \code{auth_jwt}: Authenticate with JWT token
+\item \code{auth_jwt()}: Authenticate with JWT token
 
-\item \code{auth_oauth}: Authorize via OAuth 2.0
+\item \code{auth_oauth()}: Authorize via OAuth 2.0
+
 }}
-
 \seealso{
 \code{\link[=aw_auth_with]{aw_auth_with()}}
 }

--- a/man/aw_segment_table.Rd
+++ b/man/aw_segment_table.Rd
@@ -7,7 +7,7 @@
 aw_segment_table(
   company_id = Sys.getenv("AW_COMPANY_ID"),
   rsid = Sys.getenv("AW_REPORTSUITE_ID"),
-  segmentRsids = NULL,
+  segmentRsids,
   date_range = c(Sys.Date() - 30, Sys.Date() - 1),
   metrics = c("visits", "visitors"),
   globalSegment = NULL,
@@ -20,9 +20,7 @@ aw_segment_table(
 
 \item{rsid}{Report suite ID for the data pull}
 
-\item{segmentRsids}{Vector of report suite IDs used to discover the
-human-readable segment names. Passed to \code{aw_get_segments}. If \code{NULL}, then
-takes the same value as \code{rsid}.}
+\item{segmentRsids}{Deprecated.}
 
 \item{date_range}{Date range}
 


### PR DESCRIPTION
This argument limited the usefulness of the function, without adding anything in return. Previously I thought that `aw_get_segments` required a report suite to work, and so I used to use that argument. Using NULL is better, and causes all report suites to be searched. Since segment IDs are unique, there is no loss of accuracy in searching all report suites.

Resolves #149 

## Checklist

- [x] Ran `devtools::document()`
- [x] Ran R CMD check with 0 errors, 0 warnings, and 0 notes